### PR TITLE
Add compatibility for Cabal 3.6.* inclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changelog is available [on GitHub][2].
 * [#11](https://github.com/kowainik/autopack/pull/11):
   Recognize the `.hsc` extension.
   (by [@hasufell](https://github.com/hasufell))
+* [#19](https://github.com/kowainik/autopack/pull/19)
+  Add compatibility with Cabal versions up to and including 3.6
+  (by [@ivb-supercede](https://github.com/ivb-supercede)
 
 ## 0.0.0.0
 

--- a/autopack.cabal
+++ b/autopack.cabal
@@ -59,6 +59,6 @@ library
   import:              common-options
   hs-source-dirs:      src
   exposed-modules:     Autopack
-  build-depends:       Cabal >= 2.2 && < 3.2
+  build-depends:       Cabal >= 2.2 && < 3.7
                      , dir-traverse ^>= 0.2
                      , filepath ^>= 1.4


### PR DESCRIPTION
This makes two changes:
  * For compatibility with 3.4+ without warnings, `fromComponents` has been replaced with a call to `fromString` and `intercalate`.
  * For compatibility with 3.6+, `Autopack.hs` now uses the C preprocessor with Cabal's version flags to handle a breaking change in the Cabal API around `hsSourceDirs`, which are now `SymbolicPath`s instead of `FilePath`s.

(I know `getSymbolicPath` says "Don't use this in new code", but I can't find any alternative - in the Cabal codebase, it *is* used in new code.)